### PR TITLE
Pre-Prepare 1.0

### DIFF
--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -321,6 +321,9 @@ if __name__ == "__main__":
         booth_cookie = {"_plaza_session_nktz7u": config_json['session-cookie']}
         discord_webhook_url = config_json['discord-webhook-url']
 
+        # Preference
+        image.font_init(config_json.get('changelog-font-file', 'NanumSquareNeo-bRg.ttf'), config_json.get('changelog-font-size', 16))
+
         # FIXME: Due to having PermissionError issue, clean temp stuff on each initiation.
         shutil.rmtree("./download")
         shutil.rmtree("./process")

--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -44,7 +44,12 @@ def init_update_check(product):
 
     download_url_list = download_url_list[0]
 
-    version_file_path = f'./version/{order_num}.json'
+    version_filename = product.get('custom-version-filename')
+    if version_filename is None:
+        version_filename = order_num
+    
+    version_file_path = f'./version/{version_filename}.json'
+
     if not os.path.exists(version_file_path):
         print('version file not found')
         createVersionFile(version_file_path, order_num)

--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -32,6 +32,7 @@ def init_update_check(product):
     encoding = product.get('intent-encoding')
     number_show = product.get('download-number-show')
     changelog_show = product.get('changelog-show')
+    archive_this = product.get('archive_this', True)
             
     download_short_list = list()
     thumblist = list()
@@ -75,7 +76,7 @@ def init_update_check(product):
         booth.download_item(item[0], download_path, booth_cookie)
         
         # archive stuff
-        if (item[0] not in local_list):
+        if archive_this and item[0] not in local_list:
             archive_path = archive_folder + '/' + item[1]
             shutil.copyfile(download_path, archive_path)
         

--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -175,6 +175,7 @@ def init_pathinfo(root):
             if file_info['status'] == 2: 
                 continue
             elif file != old_name:
+                file_info['status'] = 0
                 file_info['line_str'] += f'{old_name} → {file} {symbol}'
             else:
                 file_info['line_str'] += f'{file} {symbol}'

--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -84,18 +84,17 @@ def init_update_check(product):
         init_file_process(download_path, item[1], version_json, encoding)
         
     # create image from 'files' tree
-    global current_string, current_level, current_count, highest_level
-    
-    current_string = ""
+    global path_list, current_level, current_count, highest_level
+
+    path_list = []
     current_level = 0
     current_count = 0
     highest_level = 0
-    get_files_str(version_json)
+    init_pathinfo(version_json)
     
-    offset = image.get_offset(highest_level, current_count)
+    offset = image.get_image_size(highest_level, current_count)
     img = image.make_image(1024, offset[1])
-    image.print_img(img, current_string)
-    # img = img.resize(size=(2048, offset[1]))
+    image.make_pathinfo_line(img, path_list)
     img.save(changelog_img_path)
     
     # add webhook
@@ -128,13 +127,12 @@ def init_update_check(product):
     
     file.close()
 
-
-current_string = ""
+path_list = []
 current_level = 0
-current_count = 0
 highest_level = 0
-def get_files_str(root):
-    global current_string, current_level, current_count, highest_level
+current_count = 0
+def init_pathinfo(root):
+    global path_list, current_level, highest_level, current_count
     
     if highest_level < current_level:
         highest_level = current_level
@@ -146,27 +144,27 @@ def get_files_str(root):
     current_level += 1
     
     for file in files.keys():
-        filetree_str = ""
+        file_info = {'line_str': "", 'status': root['files'][file]['mark_as']}
 
         for loop in range(0, current_level - 1):
-            filetree_str += '        '
+            file_info['line_str'] += '        '
 
         symbol = ''
-        if root['files'][file]['mark_as'] == 1:
+        if file_info['status'] == 1:
             symbol = '(Added)'
-        elif root['files'][file]['mark_as'] == 2:
+        elif file_info['status'] == 2:
             symbol = '(Deleted)'
-        elif root['files'][file]['mark_as'] == 3:
+        elif file_info['status'] == 3:
             symbol = '(Changed)'
 
+        file_info['line_str'] += f'{file} {symbol}'
+
+        path_list.append(file_info)
         current_count += 1
-        filetree_str += f'{file} {symbol}'
-        current_string += filetree_str + '\n'
         
-        get_files_str(root['files'][file])
+        init_pathinfo(root['files'][file])
         
     current_level -= 1
-
 
 json_level = []
 def init_file_process(input_path, filename, version_json, encoding):

--- a/booth_checker/image.py
+++ b/booth_checker/image.py
@@ -1,7 +1,12 @@
 from PIL import Image, ImageFont, ImageDraw
 
+# TODO: WHAT HAPPENED WHEN FONT FILE DOES NOT EXIST?!?!?!?!?
 font = ImageFont.truetype('NanumSquareNeo-bRg.ttf', size=16)
 font_color = 'rgb(255, 255, 255)'
+
+def font_init(font_filename, size):
+    global font
+    font = ImageFont.truetype(font_filename, size)
 
 def print_img(img, current_string):
     draw = ImageDraw.Draw(img)

--- a/booth_checker/image.py
+++ b/booth_checker/image.py
@@ -1,8 +1,6 @@
 from PIL import Image, ImageFont, ImageDraw
 
-# TODO: WHAT HAPPENED WHEN FONT FILE DOES NOT EXIST?!?!?!?!?
-font = ImageFont.truetype('NanumSquareNeo-bRg.ttf', size=16)
-font_color = 'rgb(255, 255, 255)'
+# font = ImageFont.truetype('NanumSquareNeo-bRg.ttf', size=16)
 font_size = 16
 
 def font_init(font_filename, size):

--- a/booth_checker/image.py
+++ b/booth_checker/image.py
@@ -3,14 +3,27 @@ from PIL import Image, ImageFont, ImageDraw
 # TODO: WHAT HAPPENED WHEN FONT FILE DOES NOT EXIST?!?!?!?!?
 font = ImageFont.truetype('NanumSquareNeo-bRg.ttf', size=16)
 font_color = 'rgb(255, 255, 255)'
+font_size = 16
 
 def font_init(font_filename, size):
-    global font
+    global font, font_size
+
+    font_size = size
     font = ImageFont.truetype(font_filename, size)
 
-def print_img(img, current_string):
+def print_line(img, order, status, current_string):
+    global font
+
+    line_color = 'rgb(255, 255, 255)'
+    if status == 1:
+        line_color = 'rgb(3, 166, 166)'
+    elif status == 2:
+        line_color = 'rgb(242, 53, 123)'
+    elif status == 3:
+        line_color = 'rgb(242, 174, 46)'
+
     draw = ImageDraw.Draw(img)
-    draw.text((0, 0), current_string, font=font, fill=font_color)
+    draw.text((0, get_line_yoffset(order)), current_string, font=font, fill=line_color)
     
 
 def make_image(x, y):
@@ -18,7 +31,20 @@ def make_image(x, y):
     return image
 
 
-def get_offset(level, count):
+def make_pathinfo_line(img, path_list):
+    current_order = 0
+    for pathinfo in path_list:
+        print_line(img, current_order, pathinfo['status'], pathinfo['line_str'])
+        current_order += 1
+
+def get_line_yoffset(count):
+    global font_size
+    
+    # x_offset = 64 * level
+    y_offset = (font_size + 4) * count
+    return y_offset
+
+def get_image_size(level, count):
     x_offset = 64 * level
     y_offset = 20 * count
     return (x_offset, y_offset)

--- a/booth_checker/log.py
+++ b/booth_checker/log.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+current_time = ''
+def strftime_now():
+    global current_time
+    current_time = datetime.now().strftime('%Y-%m-%d %H %M')
+    return current_time
+
+def log_print(order_num, str):
+    global current_time
+    print(f'{current_time}: [{order_num}] {str}')
+    
+    

--- a/booth_checker/shared.py
+++ b/booth_checker/shared.py
@@ -3,7 +3,7 @@ import simdjson
 
 changelog_img_path = 'changelog_temp.png'
 
-def createVersionFile(version_file_path, order_num):
+def createVersionFile(version_file_path):
     f = open(version_file_path, 'w')
     
     short_list = {'short-list': [], 'files': {}}
@@ -14,8 +14,6 @@ def createVersionFile(version_file_path, order_num):
     
     simdjson.dump(short_list, fp = f, indent = 4)
     f.close()
-    
-    print(f'{order_num} version file created')
     
     
 def createFolder(directory):

--- a/checklist.json
+++ b/checklist.json
@@ -2,6 +2,9 @@
     "session-cookie": "YOUR_COOKIE_HERE",
     "discord-webhook-url": "YOUR_DISCORD_WEBHOOK_URL_HERE",
 
+    "changelog-font-file":  "NanumSquareNeo-bRg.ttf",
+    "changelog-font-size": 16,
+
     "products":
     [
         {

--- a/checklist.json
+++ b/checklist.json
@@ -8,6 +8,8 @@
     "products":
     [
         {
+            "custom-version-filename": "my-version",
+
             "booth-order-number": "BOOTH_ORDER_NUMBER_HERE",
             "booth-product-name": "BOOTH_PROUCT_NAME_HERE",
             "booth-check-only": [


### PR DESCRIPTION
일단 이 다음에 변경할게 좀 많을 것 같아서 지금 미리 올림..
아직은 테스트만 해주세요!

### 이 브랜치에서 남은 할 것
- [ ] 메인 아이템 지정
> 파일 이름과 내용이 같이 변경되는 경우가 해당됨
- [x] 파일 해쉬가 같은 상태에서 파일 이름만 바뀐 경우, 이름 변경만 표시되도록 변경 <<<<<<< 이거 사실 status 0으로 표기되어야 함 
> 그냥 색상으로만 표시함


### 현재까지 모든 변경사항
- CHANGELOG
    - 파일 변경 상태에 따라 글자 색이 변하도록 함
        - 변경 없음: `rgb(255, 255, 255)`
        - 파일 추가 (1): `rgb(3, 166, 166)`
        - 파일 제거 (2): `rgb(242, 53, 123)`
        - 파일 변경 (3): `rgb(242, 174, 46)`
    -  파일 해쉬가 같은 상태에서 파일 이름만 바뀐 경우, 이름 변경만 표시되도록 변경
![image](https://github.com/5ignal/booth-update-checker/assets/12884365/0d2270dc-c1f0-470f-8778-5b5ecd1265d4)


- checklist.json 
    - `'changelog-font-file'`, `'changelog-font-size'`: 폰트 커스터마이징 (기본값: `'NanumSquareNeo-bRg.ttf'`, `16`)
    #### Product  
    - `'archive_this'`: 아카이브 여부 설정 (기본값: `1`)
    - `'custom-version-filename'`: 해당 product의 변경 내역을 저장하는 version 파일 이름 지정 
         > 한 order 내에서 확인해야 할 항목이 2개 이상인 경우, 이걸 통해서 분리할 수 있음
- log
    - `REFRASH_TIME: [ORDER_NUMBER] ITEM` 형식으로 출력하도록 변경