### PR TITLE
Migrate BoothChecker storage backend from PostgreSQL to DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ BOOTH.pm의 아이템 업데이트를 주기적으로 확인하고 업데이트 
 {
     "refresh_interval": 600,
     "selenium_url": "http://chrome:4444/wd/hub",
-    "postgres": {
-        "host": "postgres",
-        "port": 5432,
-        "dbname": "booth",
-        "user": "booth_user",
-        "password": "booth_password"
+    "dynamodb": {
+        "region": "ap-northeast-2",
+        "endpoint_url": "https://dynamodb.ap-northeast-2.amazonaws.com",
+        "tables": {
+            "accounts": "booth_accounts",
+            "items": "booth_items",
+            "channels": "discord_noti_channels"
+        }
     },
     "discord_api_url": "http://booth-discord:5000",
     "discord_bot_token": "YOUR_DISCORD_BOT_TOKEN",

--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -849,8 +849,8 @@ if __name__ == "__main__":
     createFolder("./download")
     createFolder("./process")
 
-    postgres_config = dict(config_json['postgres'])
-    booth_db = booth_sql.BoothPostgres(postgres_config)
+    dynamodb_config = dict(config_json['dynamodb'])
+    booth_db = booth_sql.BoothDynamoDB(dynamodb_config)
 
     if not DRY_RUN:
         # booth_discord 컨테이너 시작 대기

--- a/booth_checker/booth_sql.py
+++ b/booth_checker/booth_sql.py
@@ -1,62 +1,169 @@
 import logging
 import time
-import psycopg
+from decimal import Decimal
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
 
 
 logger = logging.getLogger('BoothChecker')
 
 
-class BoothPostgres:
-    def __init__(self, conn_params, retries=5, delay=2):
-        self.conn = self._connect_with_retry(conn_params, retries, delay)
-        self.conn.autocommit = True
-        self.cursor = self.conn.cursor()
+def _to_decimal(value):
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
 
-    def __del__(self):
-        try:
-            self.cursor.close()
-        except Exception:
-            pass
-        try:
-            self.conn.close()
-        except Exception:
-            pass
 
-    def get_booth_items(self):
-        self.cursor.execute('''
-            SELECT  items.booth_order_number,
-                    items.booth_item_number,
-                    items.item_name,
-                    items.intent_encoding,
-                    items.download_number_show,
-                    items.changelog_show,
-                    items.archive_this,
-                    items.gift_item,
-                    items.summary_this,
-                    items.fbx_only,
-                    accounts.session_cookie,
-                    accounts.discord_user_id,
-                    channels.discord_channel_id
-            FROM booth_items items
-            INNER JOIN booth_accounts accounts
-                ON items.discord_user_id = accounts.discord_user_id
-            INNER JOIN discord_noti_channels channels
-                ON items.booth_order_number = channels.booth_order_number
-        ''')
-        return self.cursor.fetchall()
+def _to_int(value):
+    if isinstance(value, Decimal):
+        return int(value)
+    return value
 
-    def _connect_with_retry(self, conn_params, retries=5, delay=2):
+
+class BoothDynamoDB:
+    def __init__(self, config, retries=5, delay=2):
+        self.config = config
+        self.dynamodb = self._connect_with_retry(config, retries, delay)
+        self._ensure_tables()
+        tables = config['tables']
+        self.accounts_table = self.dynamodb.Table(tables['accounts'])
+        self.items_table = self.dynamodb.Table(tables['items'])
+        self.channels_table = self.dynamodb.Table(tables['channels'])
+
+    def _connect_with_retry(self, config, retries=5, delay=2):
         for attempt in range(1, retries + 1):
             try:
-                return psycopg.connect(**conn_params)
-            except psycopg.OperationalError as exc:
+                return boto3.resource(
+                    'dynamodb',
+                    region_name=config.get('region'),
+                    endpoint_url=config.get('endpoint_url'),
+                )
+            except ClientError as exc:
                 if attempt == retries:
-                    logger.error("PostgreSQL 연결에 실패했습니다. 설정을 확인해주세요.")
+                    logger.error("DynamoDB 연결에 실패했습니다. 설정을 확인해주세요.")
                     raise
                 logger.warning(
-                    "PostgreSQL 연결 재시도 %s/%s: %s",
+                    "DynamoDB 연결 재시도 %s/%s: %s",
                     attempt,
                     retries,
                     exc,
                 )
                 time.sleep(delay)
+
+    def _ensure_tables(self):
+        table_names = self.config['tables']
+        client = self.dynamodb.meta.client
+        existing = set(client.list_tables().get('TableNames', []))
+
+        if table_names['accounts'] not in existing:
+            client.create_table(
+                TableName=table_names['accounts'],
+                AttributeDefinitions=[
+                    {'AttributeName': 'discord_user_id', 'AttributeType': 'N'},
+                    {'AttributeName': 'session_cookie', 'AttributeType': 'S'},
+                ],
+                KeySchema=[{'AttributeName': 'discord_user_id', 'KeyType': 'HASH'}],
+                BillingMode='PAY_PER_REQUEST',
+                GlobalSecondaryIndexes=[
+                    {
+                        'IndexName': 'session_cookie-index',
+                        'KeySchema': [{'AttributeName': 'session_cookie', 'KeyType': 'HASH'}],
+                        'Projection': {'ProjectionType': 'ALL'},
+                    }
+                ],
+            )
+            client.get_waiter('table_exists').wait(TableName=table_names['accounts'])
+
+        if table_names['items'] not in existing:
+            client.create_table(
+                TableName=table_names['items'],
+                AttributeDefinitions=[
+                    {'AttributeName': 'booth_order_number', 'AttributeType': 'S'},
+                    {'AttributeName': 'discord_user_id', 'AttributeType': 'N'},
+                    {'AttributeName': 'booth_item_number', 'AttributeType': 'S'},
+                ],
+                KeySchema=[{'AttributeName': 'booth_order_number', 'KeyType': 'HASH'}],
+                BillingMode='PAY_PER_REQUEST',
+                GlobalSecondaryIndexes=[
+                    {
+                        'IndexName': 'discord_user_id-booth_item_number-index',
+                        'KeySchema': [
+                            {'AttributeName': 'discord_user_id', 'KeyType': 'HASH'},
+                            {'AttributeName': 'booth_item_number', 'KeyType': 'RANGE'},
+                        ],
+                        'Projection': {'ProjectionType': 'ALL'},
+                    }
+                ],
+            )
+            client.get_waiter('table_exists').wait(TableName=table_names['items'])
+
+        if table_names['channels'] not in existing:
+            client.create_table(
+                TableName=table_names['channels'],
+                AttributeDefinitions=[
+                    {'AttributeName': 'booth_order_number', 'AttributeType': 'S'},
+                    {'AttributeName': 'discord_channel_id', 'AttributeType': 'N'},
+                ],
+                KeySchema=[
+                    {'AttributeName': 'booth_order_number', 'KeyType': 'HASH'},
+                    {'AttributeName': 'discord_channel_id', 'KeyType': 'RANGE'},
+                ],
+                BillingMode='PAY_PER_REQUEST',
+                GlobalSecondaryIndexes=[
+                    {
+                        'IndexName': 'discord_channel_id-index',
+                        'KeySchema': [
+                            {'AttributeName': 'discord_channel_id', 'KeyType': 'HASH'},
+                            {'AttributeName': 'booth_order_number', 'KeyType': 'RANGE'},
+                        ],
+                        'Projection': {'ProjectionType': 'ALL'},
+                    }
+                ],
+            )
+            client.get_waiter('table_exists').wait(TableName=table_names['channels'])
+
+    def get_booth_items(self):
+        items = []
+        scan_kwargs = {}
+        while True:
+            response = self.items_table.scan(**scan_kwargs)
+            items.extend(response.get('Items', []))
+            last_key = response.get('LastEvaluatedKey')
+            if not last_key:
+                break
+            scan_kwargs['ExclusiveStartKey'] = last_key
+
+        joined_rows = []
+        for item in items:
+            discord_user_id = _to_int(item.get('discord_user_id'))
+            account = self.accounts_table.get_item(
+                Key={'discord_user_id': _to_decimal(discord_user_id)}
+            ).get('Item')
+            if not account:
+                continue
+
+            channels = self.channels_table.query(
+                KeyConditionExpression=Key('booth_order_number').eq(item['booth_order_number'])
+            ).get('Items', [])
+            for channel in channels:
+                joined_rows.append(
+                    (
+                        item.get('booth_order_number'),
+                        item.get('booth_item_number'),
+                        item.get('item_name'),
+                        item.get('intent_encoding'),
+                        item.get('download_number_show', True),
+                        item.get('changelog_show', True),
+                        item.get('archive_this', False),
+                        item.get('gift_item', False),
+                        item.get('summary_this', False),
+                        item.get('fbx_only', False),
+                        account.get('session_cookie'),
+                        discord_user_id,
+                        _to_int(channel.get('discord_channel_id')),
+                    )
+                )
+
+        return joined_rows

--- a/booth_discord/__main__.py
+++ b/booth_discord/__main__.py
@@ -41,8 +41,8 @@ def main():
 
     # Initialize database and bot
     booth_crawler = booth_module.BoothCrawler(selenium_url)
-    postgres_config = dict(config_json['postgres'])
-    booth_db = booth_sql.BoothPostgres(postgres_config, booth_crawler, logger)
+    dynamodb_config = dict(config_json['dynamodb'])
+    booth_db = booth_sql.BoothDynamoDB(dynamodb_config, booth_crawler, logger)
     bot = booth_discord.DiscordBot(booth_db, logger, fbx_only)
     bot.run(discord_bot_token)
 

--- a/config-sample.json
+++ b/config-sample.json
@@ -1,12 +1,14 @@
 {
     "refresh_interval": 600,
     "selenium_url": "http://chrome:4444/wd/hub",
-    "postgres": {
-        "host": "postgres",
-        "port": 5432,
-        "dbname": "booth",
-        "user": "booth_user",
-        "password": "booth_password"
+    "dynamodb": {
+        "region": "ap-northeast-2",
+        "endpoint_url": "https://dynamodb.ap-northeast-2.amazonaws.com",
+        "tables": {
+            "accounts": "booth_accounts",
+            "items": "booth_items",
+            "channels": "discord_noti_channels"
+        }
     },
     "discord_api_url": "http://booth-discord:5000",
     "discord_bot_token": "YOUR_DISCORD_BOT_TOKEN",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,23 +30,6 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  postgres:
-    image: postgres:18.1
-    restart: unless-stopped
-    environment:
-      POSTGRES_DB: booth
-      POSTGRES_USER: booth_user
-      POSTGRES_PASSWORD: booth_password
-    ports:
-      - "5433:5432"
-    volumes:
-      - postgres-data:/var/lib/postgresql
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
-
   chrome:
     image: selenium/standalone-chrome:latest
     restart: unless-stopped
@@ -55,6 +38,3 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-
-volumes:
-  postgres-data:

--- a/docker/booth-checker/requirements.txt
+++ b/docker/booth-checker/requirements.txt
@@ -7,4 +7,3 @@ pytz
 boto3
 jinja2
 google-genai
-psycopg[binary]

--- a/docker/booth-discord/requirements.txt
+++ b/docker/booth-discord/requirements.txt
@@ -3,4 +3,4 @@ pytz
 quart
 selenium
 beautifulsoup4
-psycopg[binary]
+boto3


### PR DESCRIPTION
### Motivation

- Replace the current PostgreSQL-backed storage with AWS DynamoDB to support a serverless, managed datastore and simplify deployment.
- Remove the on-prem Postgres dependency and related container to streamline the Docker Compose setup.
- Update configuration to expose `dynamodb` settings and table names instead of `postgres` connection parameters.

### Description

- Added `BoothDynamoDB` implementations and conversion helpers (`_to_decimal`, `_to_int`) in `booth_checker/booth_sql.py` and `booth_discord/booth_sql.py` to replace `BoothPostgres` logic and provide table creation and data access via `boto3`.
- Replaced instantiation of `BoothPostgres` with `BoothDynamoDB` in `booth_checker/__main__.py` and `booth_discord/__main__.py` to load `dynamodb` config and use the new backend.
- Updated `config-sample.json` and `README.md` to document the new `dynamodb` configuration, and updated `docker-compose.yml` to remove the Postgres service and volume.
- Removed `psycopg[binary]` from container requirement files and added `boto3` dependency in `docker/booth-checker/requirements.txt` and `docker/booth-discord/requirements.txt`.

### Testing

- No automated tests or CI runs were executed for this change.
- Basic local repository checks (file edits and commit) were performed but no runtime integration tests against DynamoDB were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949d30426808325864d3ae27e2b8c63)