### PR TITLE
develop → main: Gemini 요약/파이프라인 견고성 개선 및 모델 설정화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ changelog
 
 test.sh
 *-test.yml
+
+# Claude / AI tooling
+.claude/
+.omc/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ BOOTH.pm의 아이템 업데이트를 주기적으로 확인하고 업데이트 
     "discord_api_url": "http://booth-discord:5000",
     "discord_bot_token": "YOUR_DISCORD_BOT_TOKEN",
     "gemini_api_key": "YOUR_GEMINI_API_KEY",
+    "gemini_model": "gemini-3.5-flash-lite",
     "s3":
         {
             "endpoint_url": "YOUR_S3_ENDPOINT_URL",
@@ -43,6 +44,10 @@ changelog.html을 S3에 업로드하고, Discord Embed에서 마스킹된 링크
 #### 'gemini_api_key' (선택사항)
 
 변경점을 Google Gemini를 통해 요약합니다.
+
+#### 'gemini_model' (선택사항)
+
+요약에 사용할 Gemini 모델을 지정합니다. 생략하면 기본값 `gemini-3.5-flash-lite`를 사용합니다.
 
 ---
 

--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -3,6 +3,7 @@ import zipfile
 import hashlib
 import traceback
 import os
+import tempfile
 import requests
 import re
 import uuid
@@ -29,8 +30,16 @@ from logging_setup import attach_syslog_handler
 
 DRY_RUN = None
 
+# Base directory for per-item working folders (created/recreated each cycle).
+WORK_ROOT = './work'
+
 # Setup robust logger
 thread_local = threading.local()
+
+# Tracks which users have had their error state reset this cycle (dedup so we
+# do not POST /reset_error once per item per cycle).
+reset_users_this_cycle = set()
+reset_users_lock = threading.Lock()
 
 class ContextFilter(logging.Filter):
     def filter(self, record):
@@ -54,6 +63,12 @@ if all(not isinstance(f, ContextFilter) for f in logger.filters):
 
 class BoothCrawlError(Exception):
     """Custom exception for BOOTH crawling failures."""
+    pass
+
+class ChangelogError(Exception):
+    """Raised when changelog generation cannot be trusted (e.g. an archive
+    failed to extract/parse), so the item must be retried next cycle instead
+    of advancing the version file with a misleading diff."""
     pass
 
 # mark_as
@@ -165,13 +180,15 @@ def load_and_compare_version(order_num, download_short_list, fbx_only):
 
     return version_file_path, version_json, has_changed
 
-def process_files_for_changelog(item_data, download_url_list, local_list):
+def process_files_for_changelog(item_data, download_url_list, local_list, download_dir):
     """Downloads new files and archives them if configured."""
     item_name_list = []
-    archive_folder = f'./archive/{strftime_now()}'
+    # Namespace archives per order so concurrent items processed within the
+    # same second cannot collide on a shared timestamp folder.
+    archive_folder = f'./archive/{item_data["order_num"]}/{strftime_now()}'
 
     for download_number, filename in download_url_list:
-        download_path = f'./download/{filename}'
+        download_path = os.path.join(download_dir, filename)
         item_name_list.append(filename)
 
         should_download = item_data["changelog_show"] or item_data["archive_this"] or item_data["fbx_only"]
@@ -187,27 +204,33 @@ def process_files_for_changelog(item_data, download_url_list, local_list):
     
     return item_name_list
 
-def generate_changelog_and_summary(item_data, download_url_list, version_json):
+def generate_changelog_and_summary(item_data, download_url_list, version_json, download_dir, process_dir):
     """Generates changelog content and returns metadata.
 
     Returns:
         tuple: (changelog_html_path, s3_object_url, summary_result, diff_found, new_fbx_records)
+
+    Raises:
+        ChangelogError: if any archive fails to extract/parse, so the caller
+            can skip notifying and retry next cycle instead of emitting a diff
+            that would falsely mark unparsed files as Deleted.
     """
     if item_data["fbx_only"]:
-        return generate_fbx_changelog_and_summary(item_data, download_url_list, version_json)
+        return generate_fbx_changelog_and_summary(item_data, download_url_list, version_json, download_dir, process_dir)
 
     saved_prehash = {}
     for local_file in version_json['files'].keys():
         element_mark(version_json['files'][local_file], 2, local_file, saved_prehash)
-        
+
     for _, filename in download_url_list:
-        download_path = f'./download/{filename}'
+        download_path = os.path.join(download_dir, filename)
         logger.info(f'parsing {filename} structure')
         try:
-            process_file_tree(download_path, filename, version_json, item_data["encoding"], [])
+            process_file_tree(download_path, filename, version_json, item_data["encoding"], [], process_dir)
         except Exception as e:
             logger.error(f'An error occurred while parsing {filename}: {e}')
             logger.debug(traceback.format_exc())
+            raise ChangelogError(f'failed to parse {filename}') from e
 
     path_list = generate_path_info(version_json, saved_prehash)
     diff_found = bool(path_list)
@@ -256,19 +279,25 @@ def generate_changelog_and_summary(item_data, download_url_list, version_json):
 
     return changelog_html_path, s3_object_url, summary_result, diff_found, None
 
-def generate_fbx_changelog_and_summary(item_data, download_url_list, version_json):
-    """Generates changelog information for FBX-only tracking."""
+def generate_fbx_changelog_and_summary(item_data, download_url_list, version_json, download_dir, process_dir):
+    """Generates changelog information for FBX-only tracking.
+
+    Raises:
+        ChangelogError: if any archive fails to parse, so the caller retries
+            next cycle instead of computing an FBX diff from partial data.
+    """
     previous_fbx = version_json.get('fbx-files', {}) or {}
     current_fbx = {}
 
     for _, filename in download_url_list:
-        download_path = f'./download/{filename}'
+        download_path = os.path.join(download_dir, filename)
         logger.info(f'parsing {filename} structure (FBX only)')
         try:
-            process_file_tree(download_path, filename, None, item_data["encoding"], [], fbx_only=True, fbx_records=current_fbx)
+            process_file_tree(download_path, filename, None, item_data["encoding"], [], process_dir, fbx_only=True, fbx_records=current_fbx)
         except Exception as e:
             logger.error(f'An error occurred while parsing {filename}: {e}')
             logger.debug(traceback.format_exc())
+            raise ChangelogError(f'failed to parse {filename}') from e
 
     added_entries, changed_entries, deleted_entries = calculate_fbx_diff(previous_fbx, current_fbx)
 
@@ -396,8 +425,15 @@ def update_version_file(version_file_path, version_json, item_name_list, downloa
     elif 'fbx-files' not in version_json:
         version_json['fbx-files'] = {}
     
-    with open(version_file_path, 'w') as f:
+    # Atomic write: dump to a temp file in the same directory, fsync, then
+    # os.replace so a crash mid-write cannot truncate the version file (which
+    # would otherwise wipe short-list and trigger a full false re-notification).
+    tmp_path = f'{version_file_path}.tmp'
+    with open(tmp_path, 'w') as f:
         simdjson.dump(version_json, fp=f, indent=4)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, version_file_path)
 
 def init_update_check(item): # This is the main orchestrator function
     item_data = prepare_item_data(item)
@@ -412,6 +448,10 @@ def init_update_check(item): # This is the main orchestrator function
         logger.exception("An unexpected error occurred during fetch_booth_data")
         return
 
+    # Crawl succeeded → clear any prior error state for this user so a future
+    # failure will notify them again.
+    reset_error_notification(item_data["discord_user_id"])
+
     product_name, product_url = product_info_list[0]
     if item_data["name"] is None:
         item_data["name"] = product_name
@@ -422,42 +462,67 @@ def init_update_check(item): # This is the main orchestrator function
 
     local_list = version_json.get('short-list', [])
     local_list_name = version_json.get('name-list', [])
-    
-    item_name_list = process_files_for_changelog(item_data, download_url_list, local_list) # This is a new helper function
 
-    changelog_html_path, s3_object_url, summary_result = None, None, None
-    diff_found = download_list_changed
-    new_fbx_records = None
+    # Per-item working directories so concurrent worker threads never share
+    # ./download/<name> or ./process/<path>. Cleaned up in finally.
+    work_dir = tempfile.mkdtemp(prefix=f'{order_num}_', dir=WORK_ROOT)
+    download_dir = os.path.join(work_dir, 'download')
+    process_dir = os.path.join(work_dir, 'process')
+    os.makedirs(download_dir, exist_ok=True)
+    os.makedirs(process_dir, exist_ok=True)
 
-    if item_data["changelog_show"] or item_data["fbx_only"]:
-        changelog_html_path, s3_object_url, summary_result, calc_diff_found, new_fbx_records = generate_changelog_and_summary(
-            item_data, download_url_list, version_json
+    changelog_html_path = None
+    try:
+        item_name_list = process_files_for_changelog(item_data, download_url_list, local_list, download_dir)
+
+        s3_object_url, summary_result = None, None
+        diff_found = download_list_changed
+        new_fbx_records = None
+
+        if item_data["changelog_show"] or item_data["fbx_only"]:
+            try:
+                changelog_html_path, s3_object_url, summary_result, calc_diff_found, new_fbx_records = generate_changelog_and_summary(
+                    item_data, download_url_list, version_json, download_dir, process_dir
+                )
+            except ChangelogError as e:
+                logger.error(
+                    f'변경점 분석 실패로 알림/버전 갱신을 건너뜁니다. '
+                    f'다음 사이클에 재시도합니다. (order {order_num}): {e}'
+                )
+                return
+            if item_data["fbx_only"]:
+                diff_found = calc_diff_found
+            elif item_data["changelog_show"]:
+                diff_found = calc_diff_found or diff_found
+
+        if item_data["fbx_only"] and not diff_found:
+            logger.info('FBX contents unchanged. Skipping notification.')
+            update_version_file(version_file_path, version_json, item_name_list, download_short_list, item_data["fbx_only"], new_fbx_records)
+            return
+
+        thumb = thumblist[0] if thumblist else "https://asset.booth.pm/assets/thumbnail_placeholder_f_150x150-73e650fbec3b150090cbda36377f1a3402c01e36fa067d01.png"
+
+        delivered = send_discord_notification(
+            item_data, (product_name, product_url), thumb, local_list_name,
+            item_name_list, changelog_html_path, s3_object_url, summary_result
         )
-        if item_data["fbx_only"]:
-            diff_found = calc_diff_found
-        elif item_data["changelog_show"]:
-            diff_found = calc_diff_found or diff_found
 
-    if item_data["fbx_only"] and not diff_found:
-        logger.info('FBX contents unchanged. Skipping notification.')
+        if not delivered:
+            logger.error(
+                f'Discord 전달이 확인되지 않아 버전 파일을 갱신하지 않습니다. '
+                f'다음 사이클에 재발송됩니다. (order {order_num})'
+            )
+            return
+
         update_version_file(version_file_path, version_json, item_name_list, download_short_list, item_data["fbx_only"], new_fbx_records)
-        return
-
-    thumb = thumblist[0] if thumblist else "https://asset.booth.pm/assets/thumbnail_placeholder_f_150x150-73e650fbec3b150090cbda36377f1a3402c01e36fa067d01.png"
-
-    delivered = send_discord_notification(
-        item_data, (product_name, product_url), thumb, local_list_name,
-        item_name_list, changelog_html_path, s3_object_url, summary_result
-    )
-
-    if not delivered:
-        logger.error(
-            f'Discord 전달이 확인되지 않아 버전 파일을 갱신하지 않습니다. '
-            f'다음 사이클에 재발송됩니다. (order {order_num})'
-        )
-        return
-
-    update_version_file(version_file_path, version_json, item_name_list, download_short_list, item_data["fbx_only"], new_fbx_records)
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+        # Drop the local changelog HTML once it has been delivered/uploaded.
+        if changelog_html_path and not DRY_RUN and os.path.exists(changelog_html_path):
+            try:
+                os.remove(changelog_html_path)
+            except OSError:
+                pass
 
 def generate_path_info(root, saved_prehash):
     path_list = []
@@ -472,7 +537,9 @@ def _generate_path_info_recursive(root, saved_prehash, path_list, current_level=
     for file_name, file_node in files.items():
         file_info = {'line_str': '', 'status': file_node['mark_as']}
 
-        file_info['line_str'] += ' ' * 8 * current_level
+        # 4 spaces per level: build_tree() derives depth via indent // 4, and
+        # the FBX path (build_fbx_path_list) also uses 4-space indentation.
+        file_info['line_str'] += ' ' * 4 * current_level
 
         symbol = ''
         if file_info['status'] == 1:
@@ -499,27 +566,29 @@ def _generate_path_info_recursive(root, saved_prehash, path_list, current_level=
         path_list.append(file_info)
         _generate_path_info_recursive(file_node, saved_prehash, path_list, current_level + 1)
 
-def process_file_tree(input_path, filename, version_json, encoding, current_path, fbx_only=False, fbx_records=None):
+def process_file_tree(input_path, filename, version_json, encoding, current_path, process_dir, fbx_only=False, fbx_records=None):
     current_path.append(filename)
-    
+
     pathstr = '/'.join(current_path)
-    
+
     isdir = os.path.isdir(input_path)
     filehash = ""
     if not isdir:
         filehash = calc_file_hash(input_path)
     else:
         filehash = "DIRECTORY"
-        
-    process_path = f'./process/{pathstr}'
+
+    process_path = os.path.join(process_dir, pathstr)
     try:
-        zip_type = try_extract(input_path, filename, process_path, encoding)
+        zip_type = try_extract(input_path, filename, process_path, encoding, process_dir)
     except Exception as e:
+        # Propagate: a swallowed extraction failure would leave existing files
+        # marked Deleted (element_mark pre-marks everything as deleted), so the
+        # caller must abort the changelog and retry next cycle instead.
         logger.error(f'error occured on extracting {filename}: {e}')
         logger.debug(traceback.format_exc())
         current_path.pop()
-        end_file_process(0, process_path)
-        return
+        raise
     
     if not fbx_only:
         node = version_json
@@ -544,7 +613,7 @@ def process_file_tree(input_path, filename, version_json, encoding, current_path
     if zip_type > 0 or os.path.isdir(process_path):
         for new_filename in os.listdir(process_path):
             new_process_path = os.path.join(process_path, new_filename)
-            process_file_tree(new_process_path, new_filename, version_json, encoding, current_path, fbx_only=fbx_only, fbx_records=fbx_records)
+            process_file_tree(new_process_path, new_filename, version_json, encoding, current_path, process_dir, fbx_only=fbx_only, fbx_records=fbx_records)
 
     current_path.pop()
     end_file_process(zip_type, process_path)
@@ -559,16 +628,18 @@ def end_file_process(zip_type, process_path):
         os.remove(process_path)
     
 # NOTE: Currently, @encoding only applies on zip_type == 1
-def try_extract(input_path, input_filename, output_path, encoding):
+def try_extract(input_path, input_filename, output_path, encoding, temp_dir):
     """Extracts a file if it's a zip or unitypackage, otherwise just moves it."""
     zip_type = is_compressed(input_path)
-    
+
     if zip_type == 0:
         shutil.move(input_path, output_path)
         return zip_type
 
-    # For compressed files, move to a temporary location for extraction
-    temp_output = f'./{input_filename}'
+    # For compressed files, move to a temporary location for extraction.
+    # temp_dir is the per-item working directory, so concurrent items cannot
+    # collide on a shared CWD-root temp file.
+    temp_output = os.path.join(temp_dir, f'__extract_tmp_{input_filename}')
     shutil.move(input_path, temp_output)
     os.makedirs(output_path, exist_ok=True)
 
@@ -599,10 +670,11 @@ def is_compressed(path):
     return 0
 
 def calc_file_hash(path):
+    hash = hashlib.md5()
     with open(path, 'rb') as f:
-        data = f.read()
-        hash = hashlib.md5(data).hexdigest()
-    return hash
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
+            hash.update(chunk)
+    return hash.hexdigest()
 
 
 def element_mark(root, mark_as, current_filename, prehash_dict): 
@@ -757,7 +829,11 @@ def send_error_message(discord_channel_id, discord_user_id):
         'user_id': discord_user_id
     }
 
-    response = requests.post(api_url, json=data)
+    try:
+        response = requests.post(api_url, json=data, timeout=30)
+    except requests.RequestException as e:
+        logger.error(f'send_error_message API 요청 실패: {e}')
+        return
 
     if response.status_code == 200:
         logger.info('send_error_message API 요청 성공')
@@ -765,11 +841,57 @@ def send_error_message(discord_channel_id, discord_user_id):
         logger.error(f'send_error_message API 요청 실패: {response.text}')
     return
 
+def reset_error_notification(discord_user_id):
+    """Best-effort: tell the discord service to clear a user's accumulated error
+    state after a successful crawl, so a later failure re-notifies them. Deduped
+    per cycle to avoid one request per item."""
+    if DRY_RUN or discord_user_id is None:
+        return
+    with reset_users_lock:
+        if discord_user_id in reset_users_this_cycle:
+            return
+        reset_users_this_cycle.add(discord_user_id)
+    try:
+        requests.post(f'{discord_api_url}/reset_error', json={'user_id': discord_user_id}, timeout=10)
+    except requests.RequestException as e:
+        logger.debug(f'reset_error 요청 실패(무시): {e}')
+
 def recreate_folder(path):
     """Deletes a folder and all its contents, then recreates it."""
     if os.path.exists(path):
         shutil.rmtree(path)
     os.makedirs(path)
+
+def prune_old_archives(base_path, retention_days):
+    """Removes archive timestamp folders older than retention_days.
+
+    Archives live at ./archive/<order_num>/<timestamp>/. retention_days <= 0
+    disables pruning (keep forever).
+    """
+    if retention_days <= 0 or not os.path.isdir(base_path):
+        return
+    cutoff = datetime.now() - timedelta(days=retention_days)
+    for order_dir in os.listdir(base_path):
+        order_path = os.path.join(base_path, order_dir)
+        if not os.path.isdir(order_path):
+            continue
+        for ts_dir in os.listdir(order_path):
+            ts_path = os.path.join(order_path, ts_dir)
+            if not os.path.isdir(ts_path):
+                continue
+            try:
+                mtime = datetime.fromtimestamp(os.path.getmtime(ts_path))
+            except OSError:
+                continue
+            if mtime < cutoff:
+                logger.info(f'Pruning old archive: {ts_path}')
+                shutil.rmtree(ts_path, ignore_errors=True)
+        # Drop the order folder if it is now empty.
+        try:
+            if not os.listdir(order_path):
+                os.rmdir(order_path)
+        except OSError:
+            pass
 
 def run_update_check_safely(item):
     thread_local.order_num = item[0]
@@ -811,7 +933,10 @@ if __name__ == "__main__":
         logger.info("Gemini API key not found")
         
     refresh_interval = int(config_json['refresh_interval'])
-    
+
+    # Archive retention in days (<= 0 keeps forever). Pruned at each cycle start.
+    archive_retention_days = int(config_json.get('archive_retention_days', 30))
+
     DRY_RUN = config_json.get('dry_run', False)
     logger.info(f"Dry run is {'enabled' if DRY_RUN else 'disabled'}.")
 
@@ -838,8 +963,7 @@ if __name__ == "__main__":
     createFolder("./version/json")
     createFolder("./archive")
     createFolder("./changelog")
-    createFolder("./download")
-    createFolder("./process")
+    createFolder(WORK_ROOT)
 
     postgres_config = dict(config_json['postgres'])
     booth_db = booth_sql.BoothPostgres(postgres_config)
@@ -866,9 +990,11 @@ if __name__ == "__main__":
     while True:
         logger.info("BoothChecker cycle started")
 
-        # Recreate temporary folders
-        recreate_folder("./download")
-        recreate_folder("./process")
+        # Recreate the working root and prune stale archives.
+        recreate_folder(WORK_ROOT)
+        prune_old_archives("./archive", archive_retention_days)
+        with reset_users_lock:
+            reset_users_this_cycle.clear()
 
         booth_items = booth_db.get_booth_items()
         logger.info(f"Found {len(booth_items)} items to check.")

--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -496,7 +496,9 @@ def init_update_check(item): # This is the main orchestrator function
                 diff_found = calc_diff_found or diff_found
 
         if item_data["fbx_only"] and not diff_found:
-            logger.info('FBX contents unchanged. Skipping notification.')
+            logger.info(
+                f'FBX 변경점이 없어 알림을 건너뛰고 버전 파일만 {download_short_list}(으)로 갱신합니다. (fbx_only)'
+            )
             update_version_file(version_file_path, version_json, item_name_list, download_short_list, item_data["fbx_only"], new_fbx_records)
             return
 

--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -928,8 +928,10 @@ if __name__ == "__main__":
     # Configure global settings
     discord_api_url = config_json['discord_api_url']
     gemini_api_key = config_json.get('gemini_api_key')
+    gemini_model = config_json.get('gemini_model') or llm_summary.google_gemini_api.DEFAULT_MODEL
     if gemini_api_key:
-        summary = llm_summary.google_gemini_api(gemini_api_key)
+        summary = llm_summary.google_gemini_api(gemini_api_key, model=gemini_model)
+        logger.info("Gemini summary enabled with model: %s", gemini_model)
     else:
         summary = None
         logger.info("Gemini API key not found")

--- a/booth_checker/__main__.py
+++ b/booth_checker/__main__.py
@@ -13,7 +13,6 @@ from time import sleep
 from concurrent.futures import ThreadPoolExecutor
 from jinja2 import Environment, FileSystemLoader
 
-from operator import length_hint
 from unitypackage_extractor.extractor import extractPackage
 
 try:
@@ -148,12 +147,10 @@ def load_and_compare_version(order_num, download_short_list, fbx_only):
         version_json['short-list'] = []
 
     local_list = version_json.get('short-list', [])
-    
-    has_changed = not (
-        length_hint(local_list) == length_hint(download_short_list) and
-        ((not local_list and not download_short_list) or
-         (local_list and download_short_list and local_list[0] == download_short_list[0] and local_list[-1] == download_short_list[-1]))
-    )
+
+    # 다운로드 ID 집합 전체를 비교한다. 과거에는 길이 + 첫/끝 원소만 비교해
+    # 중간 파일만 교체되면 변경을 놓치는 경우가 있었다(순서 변화 자체는 무시).
+    has_changed = sorted(local_list) != sorted(download_short_list)
 
     if not has_changed:
         logger.info('nothing has changed.')
@@ -324,10 +321,15 @@ def generate_fbx_changelog_and_summary(item_data, download_url_list, version_jso
     return changelog_html_path, s3_object_url, summary_result, True, current_fbx
 
 def send_discord_notification(item_data, product_info, thumb, local_list_name, item_name_list, changelog_html_path, s3_object_url, summary_result):
-    """Sends update notification to Discord."""
+    """Sends update notification to Discord.
+
+    Returns True only when delivery is confirmed (every required POST returned
+    200). Returns False on any failure so the caller can skip advancing the
+    version file and have the notification re-sent on the next cycle.
+    """
     if DRY_RUN:
         logger.info('Dry run: Skipping Discord notification.')
-        return
+        return True
 
     api_url = f'{discord_api_url}/send_message'
     product_name, product_url = product_info
@@ -348,21 +350,33 @@ def send_discord_notification(item_data, product_info, thumb, local_list_name, i
         'summary': summary_result,
     }
 
-    response = requests.post(api_url, json=data)
-    
+    try:
+        response = requests.post(api_url, json=data, timeout=30)
+    except requests.RequestException as e:
+        logger.error(f'send_message API 요청 실패: {e}')
+        return False
+
     if response.status_code == 200:
         logger.info('send_message API 요청 성공')
     else:
         logger.error(f'send_message API 요청 실패: {response.text}')
-    
+        return False
+
     if item_data["changelog_show"] and changelog_html_path and not s3:
         api_url = f'{discord_api_url}/send_changelog'
         data = {'file': changelog_html_path, 'channel_id': item_data["discord_channel_id"]}
-        response = requests.post(api_url, json=data)
+        try:
+            response = requests.post(api_url, json=data, timeout=30)
+        except requests.RequestException as e:
+            logger.error(f'send_changelog API 요청 실패: {e}')
+            return False
         if response.status_code == 200:
             logger.info('send_changelog API 요청 성공')
         else:
             logger.error(f'send_changelog API 요청 실패: {response.text}')
+            return False
+
+    return True
 
 def update_version_file(version_file_path, version_json, item_name_list, download_short_list, fbx_only=False, new_fbx_records=None):
     """Cleans up and saves the updated version file."""
@@ -431,11 +445,18 @@ def init_update_check(item): # This is the main orchestrator function
 
     thumb = thumblist[0] if thumblist else "https://asset.booth.pm/assets/thumbnail_placeholder_f_150x150-73e650fbec3b150090cbda36377f1a3402c01e36fa067d01.png"
 
-    send_discord_notification(
+    delivered = send_discord_notification(
         item_data, (product_name, product_url), thumb, local_list_name,
         item_name_list, changelog_html_path, s3_object_url, summary_result
     )
-    
+
+    if not delivered:
+        logger.error(
+            f'Discord 전달이 확인되지 않아 버전 파일을 갱신하지 않습니다. '
+            f'다음 사이클에 재발송됩니다. (order {order_num})'
+        )
+        return
+
     update_version_file(version_file_path, version_json, item_name_list, download_short_list, item_data["fbx_only"], new_fbx_records)
 
 def generate_path_info(root, saved_prehash):

--- a/booth_checker/booth.py
+++ b/booth_checker/booth.py
@@ -22,9 +22,10 @@ def _extract_download_info(div, link_selector, filename_selector):
     return [match.group(1), filename]
 
 def _crawling_base(url, cookie, selectors, shortlist, thumblist, product_only_filter=None):
-    response = requests.get(url=url, cookies=cookie)
+    response = requests.get(url=url, cookies=cookie, timeout=30)
+    response.raise_for_status()
     html = response.content
-    
+
     download_url_list = []
     product_info_list = []
     soup = BeautifulSoup(html, "html.parser")
@@ -107,22 +108,30 @@ def crawling_gift(order_num, cookie, shortlist=None, thumblist=None):
 def download_item(download_number, filepath, cookie):
     url = f'https://booth.pm/downloadables/{download_number}'
     
-    response = requests.get(url=url, cookies=cookie)
-    open(filepath, "wb").write(response.content)
+    response = requests.get(url=url, cookies=cookie, timeout=60)
+    response.raise_for_status()
+    with open(filepath, "wb") as f:
+        f.write(response.content)
 
 
 def crawling_product(url):
-    response = requests.get(url)
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
     html = response.content
-    
+
     soup = BeautifulSoup(html, "html.parser")
     author_div = soup.find("a", class_="flex gap-4 items-center no-underline preserve-half-leading !text-current typography-16 w-fit")
     # None: private store
     if author_div is None:
         return None
-    
+
     author_image = author_div.select_one("img")
+    if author_image is None:
+        return None
+
     author_image_url = author_image.get("src")
     author_name = author_image.get("alt")
-    
+    if not author_image_url or not author_name:
+        return None
+
     return [author_image_url, author_name]

--- a/booth_checker/fbx_diff.py
+++ b/booth_checker/fbx_diff.py
@@ -1,5 +1,5 @@
 import os
-from collections import Counter, defaultdict
+from collections import defaultdict
 
 
 def _normalize_fbx_entries(fbx_records):
@@ -90,78 +90,75 @@ def _short_hash(file_hash):
     return file_hash[:8]
 
 
-def _append_path_context(label, basename, basename_counts, previous_path=None, current_path=None):
-    is_ambiguous_name = basename_counts[basename] > 1
-    path_changed = previous_path and current_path and previous_path != current_path
+def _group_status(statuses):
+    unique_statuses = {status for status in statuses if status != 0}
+    if not unique_statuses:
+        return 0
+    if len(unique_statuses) == 1:
+        return unique_statuses.pop()
+    return 3
 
-    if not is_ambiguous_name and not path_changed:
-        return label
 
-    if previous_path and current_path:
-        if previous_path == current_path:
-            return f"{label} {{{current_path}}}"
-        return f"{label} {{from {previous_path} -> {current_path}}}"
+def _format_added_detail(entry):
+    return f"{entry['path']} [new {_short_hash(entry['hash'])}]"
 
-    path_value = current_path or previous_path
-    return f"{label} {{{path_value}}}"
+
+def _format_deleted_detail(entry):
+    return f"{entry['path']} [old {_short_hash(entry['hash'])}]"
+
+
+def _format_changed_detail(entry):
+    if entry["previous_path"] == entry["current_path"]:
+        return (
+            f"{entry['current_path']} "
+            f"[{_short_hash(entry['previous_hash'])} -> {_short_hash(entry['current_hash'])}]"
+        )
+
+    return (
+        f"{entry['previous_path']} [old {_short_hash(entry['previous_hash'])}] -> "
+        f"{entry['current_path']} [new {_short_hash(entry['current_hash'])}]"
+    )
 
 
 def build_fbx_path_list(added_entries, changed_entries, deleted_entries):
-    basename_counts = Counter()
+    groups = defaultdict(list)
 
-    for entry in added_entries:
-        basename_counts[entry["basename"]] += 1
-    for entry in changed_entries:
-        basename_counts[entry["basename"]] += 1
-    for entry in deleted_entries:
-        basename_counts[entry["basename"]] += 1
-
-    path_list = []
-
-    for entry in added_entries:
-        label = _append_path_context(
-            entry["basename"],
-            entry["basename"],
-            basename_counts,
-            current_path=entry["path"],
-        )
-        path_list.append(
+    for entry in sorted(
+        changed_entries,
+        key=lambda item: (item["basename"], item["current_path"], item["previous_path"]),
+    ):
+        groups[entry["basename"]].append(
             {
-                "line_str": f"{label} [new {_short_hash(entry['hash'])}]",
-                "status": 1,
-            }
-        )
-
-    for entry in changed_entries:
-        label = _append_path_context(
-            entry["basename"],
-            entry["basename"],
-            basename_counts,
-            previous_path=entry["previous_path"],
-            current_path=entry["current_path"],
-        )
-        path_list.append(
-            {
-                "line_str": (
-                    f"{label} "
-                    f"[{_short_hash(entry['previous_hash'])} -> {_short_hash(entry['current_hash'])}]"
-                ),
+                "line_str": f"    {_format_changed_detail(entry)}",
                 "status": 3,
             }
         )
 
-    for entry in deleted_entries:
-        label = _append_path_context(
-            entry["basename"],
-            entry["basename"],
-            basename_counts,
-            previous_path=entry["path"],
-        )
-        path_list.append(
+    for entry in sorted(added_entries, key=lambda item: (item["basename"], item["path"])):
+        groups[entry["basename"]].append(
             {
-                "line_str": f"{label} [old {_short_hash(entry['hash'])}]",
+                "line_str": f"    {_format_added_detail(entry)}",
+                "status": 1,
+            }
+        )
+
+    for entry in sorted(deleted_entries, key=lambda item: (item["basename"], item["path"])):
+        groups[entry["basename"]].append(
+            {
+                "line_str": f"    {_format_deleted_detail(entry)}",
                 "status": 2,
             }
         )
+
+    path_list = []
+    for basename in sorted(groups):
+        child_items = groups[basename]
+        path_list.append(
+            {
+                "line_str": basename,
+                "status": _group_status(item["status"] for item in child_items),
+            }
+        )
+        path_list.extend(child_items)
 
     return path_list

--- a/booth_checker/llm_summary.py
+++ b/booth_checker/llm_summary.py
@@ -13,15 +13,34 @@ class google_gemini_api:
         self.client = genai.Client(api_key=gemini_api_key)
 
     def chat(self, message):
-        response = self.client.models.generate_content(
-            model="gemini-2.5-flash",
-            config=types.GenerateContentConfig(
-                system_instruction=self.sys_instruct),
-            contents=[message]
-        )
-        text = response.candidates[0].content.parts[0].text
-        if len(text) > 1021:
-            return text[:1021] + "..."
-        else:
-            return text
+        try:
+            response = self.client.models.generate_content(
+                model="gemini-2.5-flash",
+                config=types.GenerateContentConfig(
+                    system_instruction=self.sys_instruct),
+                contents=[message]
+            )
+
+            candidates = getattr(response, "candidates", None)
+            if not candidates:
+                return ""
+
+            content = getattr(candidates[0], "content", None)
+            if content is None:
+                return ""
+
+            parts = getattr(content, "parts", None)
+            if not parts:
+                return ""
+
+            text = getattr(parts[0], "text", None)
+            if not text:
+                return ""
+
+            if len(text) > 1021:
+                return text[:1021] + "..."
+            else:
+                return text
+        except Exception:
+            return ""
         

--- a/booth_checker/llm_summary.py
+++ b/booth_checker/llm_summary.py
@@ -2,7 +2,10 @@ from google import genai
 from google.genai import types
 
 class google_gemini_api:
-    def __init__(self, gemini_api_key):
+    DEFAULT_MODEL = "gemini-3.5-flash-lite"
+
+    def __init__(self, gemini_api_key, model=None):
+        self.model = model or self.DEFAULT_MODEL
         self.sys_instruct = """
             너는 파일 리스트 요약 전문가야. 한국어로 1024자 이내로 요약해.
             내가 주는 리스트는 "{파일명} {Added/Deleted/Changed}" 형식이야.  
@@ -15,7 +18,7 @@ class google_gemini_api:
     def chat(self, message):
         try:
             response = self.client.models.generate_content(
-                model="gemini-3.5-flash",
+                model=self.model,
                 config=types.GenerateContentConfig(
                     system_instruction=self.sys_instruct),
                 contents=[message]

--- a/booth_checker/llm_summary.py
+++ b/booth_checker/llm_summary.py
@@ -15,7 +15,7 @@ class google_gemini_api:
     def chat(self, message):
         try:
             response = self.client.models.generate_content(
-                model="gemini-2.5-flash",
+                model="gemini-3.5-flash",
                 config=types.GenerateContentConfig(
                     system_instruction=self.sys_instruct),
                 contents=[message]

--- a/booth_checker/logging_setup.py
+++ b/booth_checker/logging_setup.py
@@ -1,0 +1,42 @@
+import logging
+from logging.handlers import SysLogHandler
+from typing import Optional
+
+
+def attach_syslog_handler(
+    target_logger: logging.Logger,
+    syslog_config: dict,
+    formatter: Optional[logging.Formatter] = None,
+) -> None:
+    """Attach a syslog handler to the provided logger when enabled in config."""
+    if not syslog_config or not isinstance(syslog_config, dict):
+        return
+
+    if not syslog_config.get("enabled"):
+        return
+
+    address = syslog_config.get("address")
+    if not address:
+        target_logger.warning("Syslog logging enabled but no address configured; skipping SysLogHandler setup.")
+        return
+
+    port_value = syslog_config.get("port", 514)
+    try:
+        port = int(port_value)
+    except (TypeError, ValueError):
+        target_logger.warning("Invalid syslog port '%s'; skipping SysLogHandler setup.", port_value)
+        return
+
+    if any(isinstance(handler, SysLogHandler) for handler in target_logger.handlers):
+        return
+
+    try:
+        syslog_handler = SysLogHandler(address=(address, port))
+    except OSError as exc:
+        target_logger.error("Failed to initialize SysLogHandler for %s:%s: %s", address, port, exc)
+        return
+
+    if formatter:
+        syslog_handler.setFormatter(formatter)
+
+    target_logger.addHandler(syslog_handler)

--- a/booth_discord/booth_discord.py
+++ b/booth_discord/booth_discord.py
@@ -146,20 +146,24 @@ class DiscordBot(commands.Bot):
             s3_object_url = data.get("s3_object_url")
             summary = data.get("summary")
 
-            await self.send_message(
-                name,
-                url,
-                thumb,
-                item_number,
-                local_version_list,
-                download_short_list,
-                author_info,
-                number_show,
-                changelog_show,
-                channel_id,
-                s3_object_url,
-                summary
-            )
+            try:
+                await self.send_message(
+                    name,
+                    url,
+                    thumb,
+                    item_number,
+                    local_version_list,
+                    download_short_list,
+                    author_info,
+                    number_show,
+                    changelog_show,
+                    channel_id,
+                    s3_object_url,
+                    summary
+                )
+            except Exception as e:
+                self.logger.exception("send_message failed")
+                return jsonify({"status": "send failed", "error": str(e)}), 502
 
             return jsonify({"status": "Message sent"}), 200
 
@@ -176,7 +180,11 @@ class DiscordBot(commands.Bot):
             data = await request.get_json()
             channel_id = data.get("channel_id")
             file = data.get("file")
-            await self.send_changelog(channel_id, file)
+            try:
+                await self.send_changelog(channel_id, file)
+            except Exception as e:
+                self.logger.exception("send_changelog failed")
+                return jsonify({"status": "send failed", "error": str(e)}), 502
             return jsonify({"status": "Message sent"}), 200
 
     async def send_message(self, name, url, thumb, item_number, local_version_list, download_short_list, author_info, number_show, changelog_show, channel_id, s3_object_url=None, summary=None):
@@ -213,12 +221,12 @@ class DiscordBot(commands.Bot):
             embed.add_field(name="요약", value=str(summary), inline=False)
         embed.set_footer(text="BOOTH.pm", icon_url="https://booth.pm/static-images/pwa/icon_size_128.png")
 
-        channel = self.get_channel(int(channel_id))
+        channel = self.get_channel(int(channel_id)) or await self.fetch_channel(int(channel_id))
         await channel.send(content="@here", embed=embed)
 
     async def send_error_message(self, channel_id, discord_user_id):
-        channel = self.get_channel(int(channel_id))
-        
+        channel = self.get_channel(int(channel_id)) or await self.fetch_channel(int(channel_id))
+
         key = f'{discord_user_id}_error_count'
         count = self.error_counts.get(key, 0) + 1
         self.logger.warning(f"Error checking items for user {discord_user_id}. Error count: {count}")
@@ -243,7 +251,7 @@ class DiscordBot(commands.Bot):
             self.logger.info(f"Sent persistent error notification to user {discord_user_id}")
 
     async def send_changelog(self, channel_id, file):
-        channel = self.get_channel(int(channel_id))
+        channel = self.get_channel(int(channel_id)) or await self.fetch_channel(int(channel_id))
         await channel.send(file=discord.File(file))
 
     async def on_ready(self):

--- a/booth_discord/booth_discord.py
+++ b/booth_discord/booth_discord.py
@@ -24,19 +24,23 @@ class DiscordBot(commands.Bot):
 
     async def setup_hook(self):
         # 봇이 로그인된 후, 준비되기 전에 호출되는 메서드
-        # 여기서 웹 서버를 시작합니다.
-        asyncio.create_task(self.run_app())
+        # 여기서 웹 서버를 시작합니다. 태스크 참조를 보관해 GC를 방지합니다.
+        self._app_task = asyncio.create_task(self.run_app())
 
     async def run_app(self):
         # Quart 앱 실행
-        await self.app.run_task(host='0.0.0.0', port=5000)
+        try:
+            await self.app.run_task(host='0.0.0.0', port=5000)
+        except Exception:
+            self.logger.exception("Quart app crashed")
+            raise
 
     def setup_commands(self):
         @self.tree.command(name="booth", description="BOOTH 계정 등록")
         @app_commands.describe(cookie="""BOOTH.pm의 "_plaza_session_nktz7u"의 쿠키 값을 입력 해주세요""")
         async def booth(interaction: discord.Interaction, cookie: str):
             try:
-                self.booth_db.add_booth_account(cookie, interaction.user.id)
+                await asyncio.to_thread(self.booth_db.add_booth_account, cookie, interaction.user.id)
                 self.logger.info(f"User {interaction.user.id} is registering BOOTH account")
                 await interaction.response.send_message("BOOTH 계정 등록 완료", ephemeral=True)
             except Exception as e:
@@ -61,7 +65,8 @@ class DiscordBot(commands.Bot):
         ):
             try:
                 await interaction.response.defer(ephemeral=True)
-                self.booth_db.add_booth_item(
+                await asyncio.to_thread(
+                    self.booth_db.add_booth_item,
                     interaction.user.id,
                     interaction.channel_id,
                     item_number,
@@ -83,7 +88,7 @@ class DiscordBot(commands.Bot):
         @self.tree.command(name="booth_del", description="BOOTH 계정 등록 해제")
         async def booth_del(interaction: discord.Interaction):
             try:
-                self.booth_db.del_booth_account(interaction.user.id)
+                await asyncio.to_thread(self.booth_db.del_booth_account, interaction.user.id)
                 self.logger.info(f"User {interaction.user.id} is removing BOOTH account")
                 await interaction.response.send_message("BOOTH 계정 삭제 완료", ephemeral=True)
             except Exception as e:
@@ -94,7 +99,7 @@ class DiscordBot(commands.Bot):
         @app_commands.describe(item="BOOTH 상품 번호를 입력해주세요")
         async def item_del(interaction: discord.Interaction, item: str):
             try:
-                self.booth_db.del_booth_item(interaction.user.id, item)
+                await asyncio.to_thread(self.booth_db.del_booth_item, interaction.user.id, item)
                 self.logger.info(f"User {interaction.user.id} is removing item {item}")
                 await interaction.response.send_message(f"[{item}] 삭제 완료", ephemeral=True)
             except Exception as e:
@@ -104,7 +109,7 @@ class DiscordBot(commands.Bot):
         @self.tree.command(name="item_list", description="아이템 목록 확인")
         async def item_list(interaction: discord.Interaction):
             try:
-                items = self.booth_db.list_booth_items(interaction.user.id, interaction.channel_id)
+                items = await asyncio.to_thread(self.booth_db.list_booth_items, interaction.user.id, interaction.channel_id)
                 if items:
                     items_list = [row[0] for row in items]
                     items_list = '\n'.join([f' - {i}' for i in items_list])
@@ -121,7 +126,7 @@ class DiscordBot(commands.Bot):
         @app_commands.describe(item_number="이 채널에서 업데이트 알림을 받을 아이템 번호를 입력해주세요")
         async def noti_update(interaction: discord.Interaction, item_number: str):
             try:
-                self.booth_db.update_discord_noti_channel(interaction.user.id, interaction.channel.id, item_number)
+                await asyncio.to_thread(self.booth_db.update_discord_noti_channel, interaction.user.id, interaction.channel.id, item_number)
                 self.logger.info(f"User {interaction.user.id} is setting update notification channel")
                 await interaction.response.send_message("업데이트 알림 채널 설정 완료", ephemeral=True)
             except Exception as e:
@@ -131,7 +136,9 @@ class DiscordBot(commands.Bot):
     def setup_routes(self):
         @self.app.route("/send_message", methods=["POST"])
         async def handle_send_message():
-            data = await request.get_json()
+            data = await request.get_json(silent=True)
+            if not isinstance(data, dict):
+                return jsonify({"status": "bad request"}), 400
 
             name = data.get("name")
             url = data.get("url")
@@ -169,15 +176,32 @@ class DiscordBot(commands.Bot):
 
         @self.app.route("/send_error_message", methods=["POST"])
         async def handle_send_error_message():
-            data = await request.get_json()
+            data = await request.get_json(silent=True)
+            if not isinstance(data, dict):
+                return jsonify({"status": "bad request"}), 400
             channel_id = data.get("channel_id")
             user_id = data.get("user_id")
-            await self.send_error_message(channel_id, user_id)
+            try:
+                await self.send_error_message(channel_id, user_id)
+            except Exception as e:
+                self.logger.exception("send_error_message failed")
+                return jsonify({"status": "send failed", "error": str(e)}), 502
             return jsonify({"status": "Error message sent"}), 200
-        
+
+        @self.app.route("/reset_error", methods=["POST"])
+        async def handle_reset_error():
+            data = await request.get_json(silent=True)
+            if not isinstance(data, dict):
+                return jsonify({"status": "bad request"}), 400
+            user_id = data.get("user_id")
+            self.reset_error_count(user_id)
+            return jsonify({"status": "reset"}), 200
+
         @self.app.route("/send_changelog", methods=["POST"])
         async def handle_send_changelog():
-            data = await request.get_json()
+            data = await request.get_json(silent=True)
+            if not isinstance(data, dict):
+                return jsonify({"status": "bad request"}), 400
             channel_id = data.get("channel_id")
             file = data.get("file")
             try:
@@ -232,7 +256,7 @@ class DiscordBot(commands.Bot):
         self.logger.warning(f"Error checking items for user {discord_user_id}. Error count: {count}")
         self.error_counts[key] = count
 
-        booth_item_count = self.booth_db.get_booth_item_count(discord_user_id)
+        booth_item_count = await asyncio.to_thread(self.booth_db.get_booth_item_count, discord_user_id)
         booth_item_count = max(booth_item_count, 1)  # Enforce a minimum threshold of 1
 
         # Notify user only if errors persist for all their items and they haven't been notified yet.
@@ -249,6 +273,18 @@ class DiscordBot(commands.Bot):
             )
             await channel.send(content=f'<@{discord_user_id}>', embed=embed)
             self.logger.info(f"Sent persistent error notification to user {discord_user_id}")
+
+    def reset_error_count(self, discord_user_id):
+        """Clears a user's accumulated error state after a successful check, so a
+        later failure (e.g. a fresh cookie expiry) notifies them again instead of
+        being permanently suppressed."""
+        if discord_user_id is None:
+            return
+        key = f'{discord_user_id}_error_count'
+        had_state = self.error_counts.pop(key, None) is not None or discord_user_id in self.error_count_user
+        self.error_count_user.discard(discord_user_id)
+        if had_state:
+            self.logger.info(f"Reset error state for user {discord_user_id}")
 
     async def send_changelog(self, channel_id, file):
         channel = self.get_channel(int(channel_id)) or await self.fetch_channel(int(channel_id))

--- a/booth_discord/booth_sql.py
+++ b/booth_discord/booth_sql.py
@@ -1,3 +1,5 @@
+import functools
+import threading
 import time
 from contextlib import contextmanager
 
@@ -5,10 +7,19 @@ import psycopg
 from psycopg import errors as pg_errors
 
 
+def _synchronized(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        with self._lock:
+            return method(self, *args, **kwargs)
+    return wrapper
+
+
 class BoothPostgres:
     def __init__(self, conn_params, booth, logger):
         self.logger = logger
         self.booth = booth
+        self._lock = threading.RLock()
         self.conn = self._connect_with_retry(conn_params)
         self.conn.autocommit = True
 
@@ -75,6 +86,7 @@ class BoothPostgres:
             with self.conn.cursor() as cursor:
                 yield cursor
 
+    @_synchronized
     def add_booth_account(self, session_cookie, discord_user_id):
         with self.conn.cursor() as cursor:
             cursor.execute('''
@@ -100,6 +112,7 @@ class BoothPostgres:
                 ''', (session_cookie, discord_user_id))
         return self.get_booth_account(discord_user_id)
 
+    @_synchronized
     def add_booth_item(self, discord_user_id, discord_channel_id, booth_item_number, booth_order_number, item_name, intent_encoding, summary_this, fbx_only):
         booth_account = self.get_booth_account(discord_user_id)
         if self.is_item_duplicate(booth_item_number, discord_user_id):
@@ -150,6 +163,7 @@ class BoothPostgres:
             raise Exception("아이템 등록 중 충돌이 발생했습니다.") from exc
         return booth_order_info[1]
 
+    @_synchronized
     def del_booth_account(self, discord_user_id):
         try:
             with self.conn.cursor() as cursor:
@@ -168,9 +182,10 @@ class BoothPostgres:
                     DELETE FROM booth_accounts WHERE discord_user_id = %s
                 ''', (discord_user_id,))
                 return cursor.rowcount
-        except Exception as exc:
-            raise Exception(exc)
+        except Exception:
+            raise
 
+    @_synchronized
     def del_booth_item(self, discord_user_id, booth_item_number):
         booth_account = self.get_booth_account(discord_user_id)
         if not booth_account:
@@ -201,9 +216,10 @@ class BoothPostgres:
                 ''', (booth_item_number, discord_user_id))
                 deleted_items = cursor.rowcount
             return {'items_deleted': deleted_items, 'channels_deleted': deleted_channels}
-        except Exception as exc:
-            raise Exception(exc)
+        except Exception:
+            raise
 
+    @_synchronized
     def get_booth_account(self, discord_user_id):
         with self.conn.cursor() as cursor:
             cursor.execute('''
@@ -213,6 +229,7 @@ class BoothPostgres:
             result = cursor.fetchone()
         return result if result else None
 
+    @_synchronized
     def is_item_duplicate(self, booth_item_number, discord_user_id):
         with self.conn.cursor() as cursor:
             cursor.execute('''
@@ -221,6 +238,7 @@ class BoothPostgres:
             ''', (booth_item_number, discord_user_id))
             return cursor.fetchone() is not None
 
+    @_synchronized
     def list_booth_items(self, discord_user_id, discord_channel_id):
         booth_account = self.get_booth_account(discord_user_id)
         if not booth_account:
@@ -237,6 +255,7 @@ class BoothPostgres:
             ''', (discord_user_id, discord_channel_id))
             return cursor.fetchall()
 
+    @_synchronized
     def add_discord_noti_channel(self, discord_channel_id, booth_order_number, use_transaction=True, cursor=None):
         if cursor is not None:
             return self._insert_discord_noti_channel(cursor, discord_channel_id, booth_order_number)
@@ -246,6 +265,7 @@ class BoothPostgres:
         with self.conn.cursor() as standalone_cursor:
             return self._insert_discord_noti_channel(standalone_cursor, discord_channel_id, booth_order_number)
 
+    @_synchronized
     def del_discord_noti_channel(self, booth_order_number, use_transaction=True, cursor=None):
         self.logger.debug("del_discord_noti_channel - booth_order_number : %s", booth_order_number)
         if cursor is not None:
@@ -256,6 +276,7 @@ class BoothPostgres:
         with self.conn.cursor() as standalone_cursor:
             return self._delete_discord_noti_channel(standalone_cursor, booth_order_number)
 
+    @_synchronized
     def update_discord_noti_channel(self, discord_user_id, discord_channel_id, booth_item_number):
         booth_order_number = self.get_booth_order_number(booth_item_number, discord_user_id)
         if not booth_order_number:
@@ -268,6 +289,7 @@ class BoothPostgres:
             ''', (discord_channel_id, booth_order_number))
             return cursor.rowcount
 
+    @_synchronized
     def get_booth_order_number(self, booth_item_number, discord_user_id):
         with self.conn.cursor() as cursor:
             cursor.execute('''
@@ -277,6 +299,7 @@ class BoothPostgres:
             result = cursor.fetchone()
         return result[0] if result else None
     
+    @_synchronized
     def get_booth_item_count(self, discord_user_id):
         with self.conn.cursor() as cursor:
             cursor.execute('SELECT COUNT(*) FROM booth_items WHERE discord_user_id = %s', (discord_user_id,))

--- a/booth_discord/logging_setup.py
+++ b/booth_discord/logging_setup.py
@@ -1,0 +1,42 @@
+import logging
+from logging.handlers import SysLogHandler
+from typing import Optional
+
+
+def attach_syslog_handler(
+    target_logger: logging.Logger,
+    syslog_config: dict,
+    formatter: Optional[logging.Formatter] = None,
+) -> None:
+    """Attach a syslog handler to the provided logger when enabled in config."""
+    if not syslog_config or not isinstance(syslog_config, dict):
+        return
+
+    if not syslog_config.get("enabled"):
+        return
+
+    address = syslog_config.get("address")
+    if not address:
+        target_logger.warning("Syslog logging enabled but no address configured; skipping SysLogHandler setup.")
+        return
+
+    port_value = syslog_config.get("port", 514)
+    try:
+        port = int(port_value)
+    except (TypeError, ValueError):
+        target_logger.warning("Invalid syslog port '%s'; skipping SysLogHandler setup.", port_value)
+        return
+
+    if any(isinstance(handler, SysLogHandler) for handler in target_logger.handlers):
+        return
+
+    try:
+        syslog_handler = SysLogHandler(address=(address, port))
+    except OSError as exc:
+        target_logger.error("Failed to initialize SysLogHandler for %s:%s: %s", address, port, exc)
+        return
+
+    if formatter:
+        syslog_handler.setFormatter(formatter)
+
+    target_logger.addHandler(syslog_handler)

--- a/config-sample.json
+++ b/config-sample.json
@@ -1,5 +1,6 @@
 {
     "refresh_interval": 600,
+    "archive_retention_days": 30,
     "selenium_url": "http://chrome:4444/wd/hub",
     "postgres": {
         "host": "postgres",

--- a/config-sample.json
+++ b/config-sample.json
@@ -12,6 +12,7 @@
     "discord_api_url": "http://booth-discord:5000",
     "discord_bot_token": "YOUR_DISCORD_BOT_TOKEN",
     "gemini_api_key": "YOUR_GEMINI_API_KEY",
+    "gemini_model": "gemini-3.5-flash-lite",
     "s3":
         {
             "endpoint_url": "YOUR_S3_ENDPOINT_URL",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   booth-checker:
-    image: ghcr.io/max-flavor/booth-checker:latest
+    image: ghcr.io/kurovinyl/booth-checker:latest
     volumes:
       - ./version:/root/boothchecker/version
       - ./archive:/root/boothchecker/archive
@@ -16,13 +16,13 @@ services:
         max-file: "3"
       
   booth-discord:
-    image: ghcr.io/max-flavor/booth-discord:latest
+    image: ghcr.io/kurovinyl/booth-discord:latest
     volumes:
       - ./version:/root/boothchecker/version
       - ./changelog:/root/boothchecker/changelog
       - ./config.json:/root/boothchecker/config.json
     depends_on:
-      - porstgres
+      - postgres
       - chrome
     restart: unless-stopped
     logging:

--- a/tests/test_fbx_diff.py
+++ b/tests/test_fbx_diff.py
@@ -24,15 +24,22 @@ class FbxDiffTests(unittest.TestCase):
         self.assertEqual(changed[0]["current_hash"], "bbbbbbbb22222222")
 
         path_list = build_fbx_path_list(added, changed, deleted)
-        self.assertEqual(path_list, [
-            {
-                "line_str": (
-                    "model.fbx {from old_package/model.fbx -> new_package/model.fbx} "
-                    "[aaaaaaaa -> bbbbbbbb]"
-                ),
-                "status": 3,
-            }
-        ])
+        self.assertEqual(
+            path_list,
+            [
+                {
+                    "line_str": "model.fbx",
+                    "status": 3,
+                },
+                {
+                    "line_str": (
+                        "    old_package/model.fbx [old aaaaaaaa] -> "
+                        "new_package/model.fbx [new bbbbbbbb]"
+                    ),
+                    "status": 3,
+                },
+            ],
+        )
 
     def test_duplicate_basenames_keep_unchanged_entries_out_of_diff(self):
         previous_fbx = {
@@ -58,6 +65,58 @@ class FbxDiffTests(unittest.TestCase):
                     "previous_path": "pack_b/model.fbx",
                     "current_path": "pack_c/model.fbx",
                 }
+            ],
+        )
+
+        path_list = build_fbx_path_list(added, changed, deleted)
+        self.assertEqual(
+            path_list,
+            [
+                {
+                    "line_str": "model.fbx",
+                    "status": 3,
+                },
+                {
+                    "line_str": (
+                        "    pack_b/model.fbx [old oldhash1] -> "
+                        "pack_c/model.fbx [new newhash2]"
+                    ),
+                    "status": 3,
+                },
+            ],
+        )
+
+    def test_same_basename_entries_are_grouped_under_one_parent(self):
+        added = [
+            {
+                "basename": "model.fbx",
+                "path": "pack_a/model.fbx",
+                "hash": "hashaaaa11",
+            },
+            {
+                "basename": "model.fbx",
+                "path": "pack_b/model.fbx",
+                "hash": "hashbbbb22",
+            },
+        ]
+
+        path_list = build_fbx_path_list(added, [], [])
+
+        self.assertEqual(
+            path_list,
+            [
+                {
+                    "line_str": "model.fbx",
+                    "status": 1,
+                },
+                {
+                    "line_str": "    pack_a/model.fbx [new hashaaaa]",
+                    "status": 1,
+                },
+                {
+                    "line_str": "    pack_b/model.fbx [new hashbbbb]",
+                    "status": 1,
+                },
             ],
         )
 


### PR DESCRIPTION
## 개요
develop 브랜치에 누적된 변경점을 main으로 병합합니다.

## 주요 변경
### Feature
- **Gemini 요약 모델 config 설정화**: `config`의 `gemini_model` 값으로 요약 모델 지정, 생략 시 기본값 사용. 기본 모델을 `gemini-3.5-flash-lite`로 설정. (`config-sample.json`/README 문서화)

### Fix
- 파이프라인 동시성·정합성·정리 개선
- Gemini 응답 파싱 안전 처리
- 크롤링 HTTP 견고성 및 파일 핸들 누수 수정
- Discord 이벤트 루프 블로킹 제거, DB 스레드 안전성/알림 견고성 개선
- Discord 알림 발송 실패 시 버전 미반영으로 재발송 보장
- FBX changelog에서 동일 basename 다수 등장 시 가독성 개선

### Chore / etc.
- syslog 로깅 핸들러 모듈(`logging_setup`) 추가
- `fbx_only` 알림 스킵 시 버전 파일 갱신 내역 로그 기록
- docker-compose 업데이트
- 클로드/AI 툴링 산출물 gitignore 추가
- devcontainer docker-in-docker 버전 bump 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)